### PR TITLE
Report device info, so HA will register a device.

### DIFF
--- a/custom_components/velux/cover.py
+++ b/custom_components/velux/cover.py
@@ -121,6 +121,15 @@ class VeluxCover(CoverEntity):
         return DEVICE_CLASS_WINDOW
 
     @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                (DOMAIN, self.unique_id)
+            },
+            "name": self.name,
+        }
+
+    @property
     def is_closed(self):
         """Return if the cover is closed."""
         return self.node.position.closed


### PR DESCRIPTION
With this change all devices become visible in the HA web interface.