### PR TITLE
Update pyvlx.

### DIFF
--- a/custom_components/velux/manifest.json
+++ b/custom_components/velux/manifest.json
@@ -3,7 +3,7 @@
   "name": "Velux",
   "documentation": "https://www.home-assistant.io/integrations/velux",
   "codeowners": ["@pawlizio"],
-  "requirements": ["pyvlx==0.2.17"],
+  "requirements": ["pyvlx==0.2.19"],
   "zeroconf": [
     {"type":"_http._tcp.local.","name":"velux_klf_lan*"}
     ],


### PR DESCRIPTION
Upstream HA already uses 0.2.19.